### PR TITLE
Implement subcommands.

### DIFF
--- a/tranquil-macros/Cargo.toml
+++ b/tranquil-macros/Cargo.toml
@@ -13,7 +13,6 @@ categories = []
 proc-macro = true
 
 [dependencies]
-convert_case = "0.6.0"
 indoc = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full"] }

--- a/tranquil-macros/src/lib.rs
+++ b/tranquil-macros/src/lib.rs
@@ -300,7 +300,7 @@ pub fn command_provider(_attr: TokenStream, item: TokenStream) -> TokenStream {
             fn command_map(
                 self: ::std::sync::Arc<Self>,
             ) -> ::std::result::Result<::tranquil::command::CommandMap, ::tranquil::command::CommandMapMergeError> {
-                ::tranquil::command::create_command_map([
+                ::tranquil::command::CommandMap::new([
                     #(Self::#commands(self.clone())),*
                 ])
             }

--- a/tranquil/src/bot.rs
+++ b/tranquil/src/bot.rs
@@ -14,7 +14,10 @@ use serenity::{
     framework::StandardFramework,
     http::Http,
     model::{
-        application::{command::Command, interaction::Interaction},
+        application::{
+            command::{Command, CommandOptionType},
+            interaction::Interaction,
+        },
         event::Event,
         gateway::{GatewayIntents, Ready},
         guild::{Guild, UnavailableGuild},
@@ -23,7 +26,15 @@ use serenity::{
     utils::colours as colors,
 };
 
-use crate::{command::Commands, l10n::TranslatedCommands, module::Module, AnyError, AnyResult};
+use crate::{
+    command::{
+        find_command, merge_command_maps, resolve_command_path, CommandMap, CommandMapEntry,
+        CommandMapMergeError, SubcommandMapEntry,
+    },
+    l10n::{CommandPathRef, TranslatedCommands},
+    module::Module,
+    AnyError, AnyResult,
+};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum ApplicationCommandUpdate {
@@ -36,7 +47,7 @@ pub enum ApplicationCommandUpdate {
 pub struct Bot {
     already_connected: AtomicBool,
     application_command_update: Option<ApplicationCommandUpdate>,
-    commands: Commands,
+    command_map: CommandMap,
     modules: Vec<Arc<dyn Module>>,
     translated_commands: TranslatedCommands,
 }
@@ -46,7 +57,7 @@ impl Default for Bot {
         Self {
             already_connected: Default::default(),
             application_command_update: Some(ApplicationCommandUpdate::default()),
-            commands: Default::default(),
+            command_map: Default::default(),
             modules: Default::default(),
             translated_commands: Default::default(),
         }
@@ -66,11 +77,11 @@ impl Bot {
         self
     }
 
-    pub fn register(mut self, module: impl Module + 'static) -> Self {
+    pub fn register(mut self, module: impl Module + 'static) -> Result<Self, CommandMapMergeError> {
         let module = Arc::new(module);
-        self.commands.append(&mut module.clone().commands());
+        self.command_map = merge_command_maps(self.command_map, module.clone().command_map()?)?;
         self.modules.push(module);
-        self
+        Ok(self)
     }
 
     pub async fn run(mut self, token: impl AsRef<str>) -> AnyResult<()> {
@@ -104,16 +115,65 @@ impl Bot {
     }
 
     fn create_application_commands(&self) -> Vec<CreateApplicationCommand> {
-        self.commands
+        self.command_map
             .iter()
-            .map(|command| {
+            .map(|(name, command)| {
                 let mut application_command = CreateApplicationCommand::default();
+
                 self.translated_commands
-                    .describe_command(command.name(), &mut application_command);
-                command.create_application_command(
-                    &self.translated_commands,
-                    &mut application_command,
-                );
+                    .describe_command(name, &mut application_command);
+
+                match command {
+                    CommandMapEntry::Command(command) => {
+                        command.add_options(&self.translated_commands, &mut application_command);
+                    }
+                    CommandMapEntry::Subcommands(subcommands) => {
+                        for (subcommand, entry) in subcommands {
+                            application_command.create_option(|option| {
+                                self.translated_commands.describe_subcommand(
+                                    CommandPathRef::Subcommand { name, subcommand },
+                                    option,
+                                );
+
+                                match entry {
+                                    SubcommandMapEntry::Subcommand(command) => {
+                                        option.kind(CommandOptionType::SubCommand);
+
+                                        command.add_suboptions(&self.translated_commands, option);
+                                    }
+                                    SubcommandMapEntry::Group(command_map) => {
+                                        let group = subcommand;
+                                        option.kind(CommandOptionType::SubCommandGroup);
+                                        for (subcommand, command) in command_map {
+                                            option.create_sub_option(|option| {
+                                                self.translated_commands.describe_subcommand(
+                                                    CommandPathRef::Grouped {
+                                                        name,
+                                                        group,
+                                                        subcommand,
+                                                    },
+                                                    option,
+                                                );
+
+                                                option.kind(CommandOptionType::SubCommand);
+
+                                                command.add_suboptions(
+                                                    &self.translated_commands,
+                                                    option,
+                                                );
+
+                                                option
+                                            });
+                                        }
+                                    }
+                                }
+
+                                option
+                            });
+                        }
+                    }
+                }
+
                 application_command
             })
             .collect()
@@ -276,11 +336,8 @@ impl EventHandler for Bot {
         async {
             match interaction {
                 Interaction::ApplicationCommand(interaction) => {
-                    let command_name = &interaction.data.name;
-                    let command = self
-                        .commands
-                        .iter()
-                        .find(|command| command.name() == command_name);
+                    let command_path = resolve_command_path(&interaction.data);
+                    let command = find_command(&self.command_map, &command_path);
 
                     match command {
                         Some(command) => command.run(ctx, interaction).await?,
@@ -290,7 +347,7 @@ impl EventHandler for Bot {
                                     response.interaction_response_data(|data| {
                                         data.embed(|embed| {
                                             embed.color(colors::css::DANGER).field(
-                                                format!(":x: Unknown command: `/{command_name}`"),
+                                                format!(":x: Unknown command: `/{command_path}`"),
                                                 "Bot commands are likely outdated.".to_string(),
                                                 false,
                                             )
@@ -308,7 +365,7 @@ impl EventHandler for Bot {
                         .await?
                 }
                 _ => {}
-            };
+            }
             Ok::<(), AnyError>(())
         }
         .await

--- a/tranquil/src/command.rs
+++ b/tranquil/src/command.rs
@@ -1,11 +1,22 @@
-use std::{pin::Pin, sync::Arc};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    error::Error,
+    fmt::{Debug, Display},
+    pin::Pin,
+    sync::Arc,
+};
 
 use futures::Future;
 use serenity::{
     async_trait,
     builder::{CreateApplicationCommand, CreateApplicationCommandOption},
     client::Context,
-    model::application::interaction::application_command::ApplicationCommandInteraction,
+    model::application::{
+        command::CommandOptionType,
+        interaction::application_command::{
+            ApplicationCommandInteraction, CommandData, CommandDataOption,
+        },
+    },
 };
 
 use crate::{l10n::TranslatedCommands, module::Module, AnyResult};
@@ -20,53 +31,158 @@ type CommandFunction<M> = Box<
         + Sync,
 >;
 
-pub struct Command<M: Module> {
-    name: String,
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub enum CommandPath {
+    Command {
+        name: String,
+    },
+    Subcommand {
+        name: String,
+        subcommand: String,
+    },
+    Grouped {
+        name: String,
+        group: String,
+        subcommand: String,
+    },
+}
+
+impl CommandPath {
+    pub(crate) fn name(&self) -> &str {
+        match self {
+            CommandPath::Command { name }
+            | CommandPath::Subcommand { name, .. }
+            | CommandPath::Grouped { name, .. } => name,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct InvalidCommandData;
+
+impl Display for InvalidCommandData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "invalid command data")
+    }
+}
+
+impl Error for InvalidCommandData {}
+
+pub(crate) fn resolve_command_path(command_data: &CommandData) -> CommandPath {
+    match command_data.options.as_slice() {
+        [group]
+            if group.kind == CommandOptionType::SubCommand
+                || group.kind == CommandOptionType::SubCommandGroup =>
+        {
+            match group.options.as_slice() {
+                [subcommand] if subcommand.kind == CommandOptionType::SubCommand => {
+                    CommandPath::Grouped {
+                        name: command_data.name.clone(),
+                        group: group.name.clone(),
+                        subcommand: subcommand.name.clone(),
+                    }
+                }
+                _ => CommandPath::Subcommand {
+                    name: command_data.name.clone(),
+                    subcommand: group.name.clone(),
+                },
+            }
+        }
+        _ => CommandPath::Command {
+            name: command_data.name.clone(),
+        },
+    }
+}
+
+pub fn resolve_command_options(command_data: &CommandData) -> &[CommandDataOption] {
+    match command_data.options.as_slice() {
+        [group]
+            if group.kind == CommandOptionType::SubCommand
+                || group.kind == CommandOptionType::SubCommandGroup =>
+        {
+            match group.options.as_slice() {
+                [subcommand] if subcommand.kind == CommandOptionType::SubCommand => {
+                    &subcommand.options
+                }
+                _ => &group.options,
+            }
+        }
+        _ => &command_data.options,
+    }
+}
+
+impl Display for CommandPath {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommandPath::Command { name } => write!(f, "{name}"),
+            CommandPath::Subcommand { name, subcommand } => write!(f, "{name} {subcommand}"),
+            CommandPath::Grouped {
+                name,
+                group,
+                subcommand,
+            } => write!(f, "{name} {group} {subcommand}"),
+        }
+    }
+}
+
+pub type OptionBuilder = fn(&TranslatedCommands) -> CreateApplicationCommandOption;
+
+pub struct ModuleCommand<M: Module> {
     function: CommandFunction<M>,
-    option_builders: Vec<fn(&TranslatedCommands) -> CreateApplicationCommandOption>,
+    option_builders: Vec<OptionBuilder>,
     module: Arc<M>,
 }
 
-impl<M: Module> Command<M> {
+impl<M: Module> ModuleCommand<M> {
     pub fn new(
-        name: impl Into<String>,
         function: CommandFunction<M>,
-        option_builders: impl Into<Vec<fn(&TranslatedCommands) -> CreateApplicationCommandOption>>,
+        option_builders: Vec<OptionBuilder>,
         module: Arc<M>,
     ) -> Self {
         Self {
-            name: name.into(),
             function,
-            option_builders: option_builders.into(),
+            option_builders,
             module,
         }
     }
 }
 
 #[async_trait]
-pub trait CommandImpl: Send + Sync {
-    fn name(&self) -> &str;
-    fn create_application_command(
+pub trait Command: Send + Sync {
+    fn add_options(
         &self,
         translated_commands: &TranslatedCommands,
         command: &mut CreateApplicationCommand,
     );
+
+    fn add_suboptions(
+        &self,
+        translated_commands: &TranslatedCommands,
+        option: &mut CreateApplicationCommandOption,
+    );
+
     async fn run(&self, ctx: Context, interaction: ApplicationCommandInteraction) -> AnyResult<()>;
 }
 
 #[async_trait]
-impl<M: Module> CommandImpl for Command<M> {
-    fn name(&self) -> &str {
-        &self.name
-    }
-
-    fn create_application_command(
+impl<M: Module> Command for ModuleCommand<M> {
+    fn add_options(
         &self,
         translated_commands: &TranslatedCommands,
         command: &mut CreateApplicationCommand,
     ) {
         for option_builder in &self.option_builders {
             command.add_option(option_builder(translated_commands));
+        }
+    }
+
+    fn add_suboptions(
+        &self,
+        translated_commands: &TranslatedCommands,
+        command: &mut CreateApplicationCommandOption,
+    ) {
+        for option_builder in &self.option_builders {
+            command.add_sub_option(option_builder(translated_commands));
         }
     }
 
@@ -105,13 +221,224 @@ impl<M: Module> CommandImpl for Command<M> {
     }
 }
 
+#[derive(Debug)]
+pub enum CommandMapMergeError {
+    DuplicateCommand { path: CommandPath },
+    AmbiguousSubcommand { path: CommandPath },
+}
+
+impl Error for CommandMapMergeError {}
+
+impl Display for CommandMapMergeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            CommandMapMergeError::DuplicateCommand { path } => {
+                write!(f, "duplicate command `/{path}`")
+            }
+            CommandMapMergeError::AmbiguousSubcommand { path } => {
+                write!(f, "command `/{path}` cannot also have subcommands")
+            }
+        }
+    }
+}
+
 pub struct CommandContext {
     pub ctx: Context,
     pub interaction: ApplicationCommandInteraction,
 }
 
-pub type Commands = Vec<Box<dyn CommandImpl>>;
+pub enum SubcommandMapEntry {
+    Subcommand(Box<dyn Command>),
+    Group(HashMap<String, Box<dyn Command>>),
+}
+
+pub type SubcommandMap = HashMap<String, SubcommandMapEntry>;
+
+pub enum CommandMapEntry {
+    Command(Box<dyn Command>),
+    Subcommands(SubcommandMap),
+}
+
+pub type CommandMap = HashMap<String, CommandMapEntry>;
+
+fn command_map_entry(path: CommandPath, command: Box<dyn Command>) -> (String, CommandMapEntry) {
+    match path {
+        CommandPath::Command { name } => (name, CommandMapEntry::Command(command)),
+        CommandPath::Subcommand { name, subcommand } => (
+            name,
+            CommandMapEntry::Subcommands(
+                [(subcommand, SubcommandMapEntry::Subcommand(command))].into(),
+            ),
+        ),
+        CommandPath::Grouped {
+            name,
+            group,
+            subcommand,
+        } => (
+            name,
+            CommandMapEntry::Subcommands(
+                [(
+                    group,
+                    SubcommandMapEntry::Group([(subcommand, command)].into()),
+                )]
+                .into(),
+            ),
+        ),
+    }
+}
+
+pub fn create_command_map(
+    commands: impl IntoIterator<Item = (CommandPath, Box<dyn Command>)>,
+) -> Result<CommandMap, CommandMapMergeError> {
+    merge_command_maps(
+        Default::default(),
+        commands
+            .into_iter()
+            .map(|(path, command)| command_map_entry(path, command)),
+    )
+}
+
+pub(crate) fn merge_command_maps(
+    mut command_map: CommandMap,
+    new_commands: impl IntoIterator<Item = (String, CommandMapEntry)>,
+) -> Result<CommandMap, CommandMapMergeError> {
+    for (name, new_entry) in new_commands {
+        command_map_add_entry(&mut command_map, name, new_entry)?;
+    }
+    Ok(command_map)
+}
+
+fn merge_subcommand_groups(
+    group_commandmap: &mut HashMap<String, Box<dyn Command>>,
+    name: String,
+    group: String,
+    new_group_commandmap: HashMap<String, Box<dyn Command>>,
+) -> Result<(), CommandMapMergeError> {
+    for (subcommand, new_entry) in new_group_commandmap {
+        if let Entry::Vacant(entry) = group_commandmap.entry(subcommand.clone()) {
+            entry.insert(new_entry);
+        } else {
+            Err(CommandMapMergeError::DuplicateCommand {
+                path: CommandPath::Grouped {
+                    name: name.clone(),
+                    group: group.clone(),
+                    subcommand,
+                },
+            })?
+        }
+    }
+    Ok(())
+}
+
+fn merge_subcommand_map_entry(
+    entry: &mut SubcommandMapEntry,
+    name: String,
+    subcommand: String,
+    new_entry: SubcommandMapEntry,
+) -> Result<(), CommandMapMergeError> {
+    match (entry, new_entry) {
+        (SubcommandMapEntry::Subcommand(_), SubcommandMapEntry::Subcommand(_)) => {
+            Err(CommandMapMergeError::DuplicateCommand {
+                path: CommandPath::Subcommand { name, subcommand },
+            })
+        }
+        (SubcommandMapEntry::Subcommand(_), SubcommandMapEntry::Group(_))
+        | (SubcommandMapEntry::Group(_), SubcommandMapEntry::Subcommand(_)) => {
+            Err(CommandMapMergeError::AmbiguousSubcommand {
+                path: CommandPath::Subcommand { name, subcommand },
+            })
+        }
+        (SubcommandMapEntry::Group(group), SubcommandMapEntry::Group(new_group)) => {
+            merge_subcommand_groups(group, name, subcommand, new_group)
+        }
+    }
+}
+
+fn merge_command_map_entry(
+    entry: &mut CommandMapEntry,
+    name: String,
+    new_entry: CommandMapEntry,
+) -> Result<(), CommandMapMergeError> {
+    match (entry, new_entry) {
+        (CommandMapEntry::Command(_), CommandMapEntry::Command(_)) => {
+            Err(CommandMapMergeError::DuplicateCommand {
+                path: CommandPath::Command { name },
+            })?
+        }
+        (CommandMapEntry::Command(_), CommandMapEntry::Subcommands(_))
+        | (CommandMapEntry::Subcommands(_), CommandMapEntry::Command(_)) => {
+            Err(CommandMapMergeError::AmbiguousSubcommand {
+                path: CommandPath::Command { name },
+            })?
+        }
+        (
+            CommandMapEntry::Subcommands(subcommand_map),
+            CommandMapEntry::Subcommands(new_subcommands),
+        ) => {
+            for (subcommand, new_entry) in new_subcommands {
+                match subcommand_map.entry(subcommand.clone()) {
+                    Entry::Occupied(mut entry) => merge_subcommand_map_entry(
+                        entry.get_mut(),
+                        name.clone(),
+                        subcommand,
+                        new_entry,
+                    )?,
+                    Entry::Vacant(entry) => {
+                        entry.insert(new_entry);
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+fn command_map_add_entry(
+    command_map: &mut HashMap<String, CommandMapEntry>,
+    name: String,
+    new_entry: CommandMapEntry,
+) -> Result<(), CommandMapMergeError> {
+    match command_map.entry(name.clone()) {
+        Entry::Occupied(mut entry) => merge_command_map_entry(entry.get_mut(), name, new_entry)?,
+        Entry::Vacant(entry) => {
+            entry.insert(new_entry);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn find_command<'a>(
+    command_map: &'a CommandMap,
+    command_path: &CommandPath,
+) -> Option<&'a dyn Command> {
+    command_map
+        .get(command_path.name())
+        .and_then(|entry| match (&command_path, entry) {
+            (CommandPath::Command { .. }, CommandMapEntry::Command(command)) => Some(command),
+            (
+                CommandPath::Subcommand { subcommand, .. }
+                | CommandPath::Grouped {
+                    group: subcommand, ..
+                },
+                CommandMapEntry::Subcommands(subcommand_map),
+            ) => subcommand_map
+                .get(subcommand)
+                .and_then(|entry| match (&command_path, entry) {
+                    (
+                        CommandPath::Subcommand { .. },
+                        SubcommandMapEntry::Subcommand(subcommand),
+                    ) => Some(subcommand),
+                    (
+                        CommandPath::Grouped { subcommand, .. },
+                        SubcommandMapEntry::Group(subcommands),
+                    ) => subcommands.get(subcommand),
+                    _ => None,
+                }),
+            _ => None,
+        })
+        .map(|command| command.as_ref())
+}
 
 pub trait CommandProvider {
-    fn commands(self: Arc<Self>) -> Commands;
+    fn command_map(self: Arc<Self>) -> Result<CommandMap, CommandMapMergeError>;
 }


### PR DESCRIPTION
- Automatic case conversions are no longer possible.
- Underscores are now used to separate subcommands.
- `rename` can still be used to get e.g. dashes in commands.