### PR TITLE
Some cleanup around commands.

### DIFF
--- a/tranquil/src/resolve.rs
+++ b/tranquil/src/resolve.rs
@@ -5,7 +5,9 @@ use serenity::{
     model::{
         application::{
             command::CommandOptionType,
-            interaction::application_command::{CommandDataOption, CommandDataOptionValue},
+            interaction::application_command::{
+                CommandData, CommandDataOption, CommandDataOptionValue,
+            },
         },
         channel::{Attachment, PartialChannel},
         guild::{PartialMember, Role},
@@ -413,4 +415,21 @@ macro_rules! bounded_string {
             ::std::option::Option::Some($crate::bounded_string!(@inner($max))),
         ));
     };
+}
+
+pub fn resolve_command_options(command_data: &CommandData) -> &[CommandDataOption] {
+    match command_data.options.as_slice() {
+        [group]
+            if group.kind == CommandOptionType::SubCommand
+                || group.kind == CommandOptionType::SubCommandGroup =>
+        {
+            match group.options.as_slice() {
+                [subcommand] if subcommand.kind == CommandOptionType::SubCommand => {
+                    &subcommand.options
+                }
+                _ => &group.options,
+            }
+        }
+        _ => &command_data.options,
+    }
 }


### PR DESCRIPTION
- Move some stuff around inside `command.rs`.
- Rename `Context` variables from `ctx` to `bot`.
- Use `CommandContext` as soon as possible.
- Use `bot` instead of `&bot.http` in parameters.
- Put `Module` parameter/field first everywhere.
- Remove unused `InvalidCommandData`.
- Move `resolve_command_options` to `resolve.rs`.
- Some more minor cleanup in the macro crate.