### PR TITLE
Reduce dependency features down to the minimum.

### DIFF
--- a/tranquil-macros/Cargo.toml
+++ b/tranquil-macros/Cargo.toml
@@ -14,5 +14,10 @@ proc-macro = true
 
 [dependencies]
 indoc = "1.0"
-quote = "1.0"
-syn = { version = "1.0", features = ["full"] }
+quote = { version = "1.0", default-features = false }
+syn = { version = "1.0", default-features = false, features = [
+    "full",
+    "parsing",
+    "printing",
+    "proc-macro",
+] }

--- a/tranquil-macros/src/lib.rs
+++ b/tranquil-macros/src/lib.rs
@@ -344,7 +344,7 @@ pub fn slash(attr: TokenStream, item: TokenStream) -> TokenStream {
             (
                 ::std::convert::From::from(::std::stringify!(#pat)),
                 (|l10n: &::tranquil::l10n::L10n| {
-                    let mut option = ::serenity::builder::CreateApplicationCommandOption::default();
+                    let mut option = ::tranquil::serenity::builder::CreateApplicationCommandOption::default();
                     <#ty as ::tranquil::resolve::Resolve>::describe(
                         option
                             .kind(<#ty as ::tranquil::resolve::Resolve>::KIND)
@@ -354,7 +354,7 @@ pub fn slash(attr: TokenStream, item: TokenStream) -> TokenStream {
                     // TODO: This can technically be done outside of the macro, now that the name is accessible there.
                     l10n.describe_command_option(#command_path_ref, ::std::stringify!(#pat), &mut option);
                     option
-                }) as fn(&::tranquil::l10n::L10n) -> ::serenity::builder::CreateApplicationCommandOption,
+                }) as fn(&::tranquil::l10n::L10n) -> ::tranquil::serenity::builder::CreateApplicationCommandOption,
             )
         }
     });

--- a/tranquil/Cargo.toml
+++ b/tranquil/Cargo.toml
@@ -11,16 +11,26 @@ keywords = ["bot", "commands", "discord", "framework", "serenity"]
 categories = ["api-bindings"]
 
 [dependencies]
-bounded-integer = { version = "0.5.3", features = ["std", "macro", "types"] }
+bounded-integer = { version = "0.5.3", features = ["types"] }
 dotenvy = "0.15.5"
 enumset = "1.0"
-futures = "0.3.23"
-serde = "1.0"
+futures = { version = "0.3.23", default-features = false, features = [
+    "async-await",
+] }
+serde = { version = "1.0", default-features = false }
 serde_yaml = "0.9.13"
-serde-tuple-vec-map = "1.0"
-serenity = "0.11.5"
-tokio = { version = "1.21", features = ["macros", "rt-multi-thread", "signal"] }
+serde-tuple-vec-map = { version = "1.0", default-features = false }
+serenity = { version = "0.11.5", default-features = false, features = [
+    "client",
+    "gateway",
+    "model",
+    "rustls_backend",
+] }
+tokio = { version = "1.21", default-features = false, features = ["signal"] }
 tranquil-macros = { version = "0.1.0", path = "../tranquil-macros" }
 
 [dev-dependencies]
 indoc = "1.0"
+tokio = { version = "1.21", default-features = false, features = [
+    "rt-multi-thread",
+] }

--- a/tranquil/src/bot.rs
+++ b/tranquil/src/bot.rs
@@ -11,7 +11,6 @@ use serenity::{
     async_trait,
     builder::CreateApplicationCommand,
     client::{Context, EventHandler, RawEventHandler},
-    framework::StandardFramework,
     http::Http,
     model::{
         application::{
@@ -24,6 +23,7 @@ use serenity::{
         id::GuildId,
     },
     utils::colours as colors,
+    Client,
 };
 
 use crate::{
@@ -94,12 +94,10 @@ impl Bot {
 
         self.load_translations().await?;
 
-        let framework = StandardFramework::new();
         let intents = merge_intents(self.modules.iter().map(Deref::deref));
 
-        serenity::Client::builder(discord_token, intents)
+        Client::builder(discord_token, intents)
             .event_handler(self)
-            .framework(framework)
             .await?
             .start()
             .await?;


### PR DESCRIPTION
- Get rid of unused `serenity::StandardFramework`.
- Fix missing `::tranquil` in macro namespace resolution.