### PR TITLE
Make `CommandL10nProvider` more flexible.

### DIFF
--- a/tranquil/examples/l10n/example_module.rs
+++ b/tranquil/examples/l10n/example_module.rs
@@ -1,6 +1,7 @@
+use serenity::async_trait;
 use tranquil::{
     command::CommandContext,
-    l10n::CommandL10nProvider,
+    l10n::{CommandL10nProvider, L10n, L10nLoadError},
     macros::{command_provider, slash, Choices},
     module::Module,
     AnyResult,
@@ -10,9 +11,10 @@ pub(crate) struct ExampleModule;
 
 impl Module for ExampleModule {}
 
+#[async_trait]
 impl CommandL10nProvider for ExampleModule {
-    fn l10n_path(&self) -> Option<&str> {
-        Some("tranquil/examples/l10n/example_module_l10n.yaml")
+    async fn l10n(&self) -> Result<L10n, L10nLoadError> {
+        L10n::from_yaml_file("tranquil/examples/l10n/example_module_l10n.yaml").await
     }
 }
 

--- a/tranquil/src/bot.rs
+++ b/tranquil/src/bot.rs
@@ -116,8 +116,11 @@ impl Bot {
 
     async fn load_translations(&mut self) -> AnyResult<()> {
         self.l10n =
-            L10n::from_yaml_files(self.modules.iter().filter_map(|module| module.l10n_path()))
-                .await?;
+            L10n::merge_results(join_all(self.modules.iter().map(|module| module.l10n())).await)
+                .map_err(|error| {
+                    eprintln!("{error}");
+                    "invalid l10n"
+                })?;
 
         Ok(())
     }


### PR DESCRIPTION
- Return a `L10n` instance instead of a filepath.
- Convert `from_yaml_files` into a `merge_results` function.
- Skip serializing empty `L10n` root nodes.