### PR TITLE
Simplify `Context` types using the delegate crate.

### DIFF
--- a/tranquil/Cargo.toml
+++ b/tranquil/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["api-bindings"]
 anyhow = "1.0"
 async-trait = "0.1.64"
 bounded-integer = { version = "0.5.3", features = ["types"] }
+delegate = "0.9.0"
 dotenvy = "0.15.5"
 enumset = "1.0"
 futures = { version = "0.3.23", default-features = false, features = [

--- a/tranquil/examples/autocomplete/autocomplete_module.rs
+++ b/tranquil/examples/autocomplete/autocomplete_module.rs
@@ -19,7 +19,7 @@ impl AutocompleteModule {
     ) -> anyhow::Result<()> {
         let you_typed = format!("You typed: {value}");
 
-        ctx.create_response(|response| response.add_string_choice(you_typed, value))
+        ctx.create_autocomplete_response(|response| response.add_string_choice(you_typed, value))
             .await?;
 
         Ok(())
@@ -40,7 +40,7 @@ impl AutocompleteModule {
         let optional_autocompleted_completion =
             format!("optional_autocompleted: {optional_autocompleted:?}");
 
-        ctx.create_response(|response| {
+        ctx.create_autocomplete_response(|response| {
             response
                 .add_string_choice(
                     not_autocompleted_completion,
@@ -72,7 +72,7 @@ impl AutocompleteModule {
         ctx: CommandContext,
         value: Autocomplete<String>,
     ) -> anyhow::Result<()> {
-        ctx.create_response(|response| {
+        ctx.create_interaction_response(|response| {
             response
                 .interaction_response_data(|data| data.content(format!("```rust\n{value:?}\n```")))
         })
@@ -89,7 +89,7 @@ impl AutocompleteModule {
         optional: Option<String>,
         optional_autocompleted: Autocomplete<Option<String>>,
     ) -> anyhow::Result<()> {
-        ctx.create_response(|response| {
+        ctx.create_interaction_response(|response| {
             response.interaction_response_data(|data| {
                 data.content(format!(
                     indoc! {r#"

--- a/tranquil/examples/l10n/example_module.rs
+++ b/tranquil/examples/l10n/example_module.rs
@@ -18,7 +18,7 @@ impl CommandL10nProvider for ExampleModule {
 }
 
 async fn pong(ctx: CommandContext) -> anyhow::Result<()> {
-    ctx.create_response(|response| {
+    ctx.create_interaction_response(|response| {
         response.interaction_response_data(|data| data.content("Pong!"))
     })
     .await?;

--- a/tranquil/examples/options/echo_module.rs
+++ b/tranquil/examples/options/echo_module.rs
@@ -166,7 +166,7 @@ impl EchoModule {
     //     ctx: CommandContext,
     //     value: PartialForumChannel,
     // ) -> anyhow::Result<()> {
-    //     create_response(ctx, value).await
+    //     echo(ctx, value).await
     // }
 
     #[slash(rename = "echo channel-id")]
@@ -284,7 +284,7 @@ impl EchoModule {
     //     ctx: CommandContext,
     //     value: ForumChannel,
     // ) -> anyhow::Result<()> {
-    //     create_response(ctx, value).await
+    //     echo(ctx, value).await
     // }
 
     // --- integer
@@ -525,7 +525,7 @@ impl EchoModule {
 }
 
 async fn echo(ctx: CommandContext, value: impl std::fmt::Debug) -> anyhow::Result<()> {
-    ctx.create_response(|response| {
+    ctx.create_interaction_response(|response| {
         response.interaction_response_data(|data| data.content(format!("```rust\n{value:#?}\n```")))
     })
     .await?;

--- a/tranquil/examples/ping_module/ping_module.rs
+++ b/tranquil/examples/ping_module/ping_module.rs
@@ -12,7 +12,7 @@ pub(crate) struct PingModule;
 impl PingModule {
     #[slash]
     async fn ping(&self, ctx: CommandContext) -> anyhow::Result<()> {
-        ctx.create_response(|response| {
+        ctx.create_interaction_response(|response| {
             response.interaction_response_data(|data| data.content("Pong!"))
         })
         .await?;

--- a/tranquil/examples/subcommands/subcommand_module.rs
+++ b/tranquil/examples/subcommands/subcommand_module.rs
@@ -9,7 +9,7 @@ use tranquil::{
 pub(crate) struct SubcommandModule;
 
 async fn pong(ctx: CommandContext) -> anyhow::Result<()> {
-    ctx.create_response(|response| {
+    ctx.create_interaction_response(|response| {
         response.interaction_response_data(|data| data.content("Pong!"))
     })
     .await?;

--- a/tranquil/src/autocomplete.rs
+++ b/tranquil/src/autocomplete.rs
@@ -1,6 +1,7 @@
 use std::{pin::Pin, sync::Arc};
 
 use async_trait::async_trait;
+use delegate::delegate;
 use futures::Future;
 use serenity::{
     builder::{CreateApplicationCommandOption, CreateAutocompleteResponse},
@@ -22,13 +23,16 @@ pub struct AutocompleteContext {
 }
 
 impl AutocompleteContext {
-    pub async fn create_response<F>(&self, f: F) -> serenity::Result<()>
-    where
-        F: FnOnce(&mut CreateAutocompleteResponse) -> &mut CreateAutocompleteResponse,
-    {
-        self.interaction
-            .create_autocomplete_response(&self.bot, f)
-            .await
+    delegate! {
+        to self.interaction {
+            pub async fn create_autocomplete_response<F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<()>
+            where
+                F: FnOnce(&mut CreateAutocompleteResponse) -> &mut CreateAutocompleteResponse;
+        }
     }
 }
 

--- a/tranquil/src/command.rs
+++ b/tranquil/src/command.rs
@@ -7,6 +7,7 @@ use std::{
 
 use anyhow::bail;
 use async_trait::async_trait;
+use delegate::delegate;
 use futures::Future;
 use serenity::{
     builder::{
@@ -38,79 +39,71 @@ pub struct CommandContext {
 }
 
 impl CommandContext {
-    pub async fn get_response(&self) -> serenity::Result<Message> {
-        self.interaction.get_interaction_response(&self.bot).await
-    }
+    delegate! {
+        to self.interaction {
+            pub async fn get_interaction_response(
+                &self,
+                [ &self.bot ],
+            ) -> serenity::Result<Message>;
 
-    pub async fn create_response<'a, F>(&self, f: F) -> serenity::Result<()>
-    where
-        for<'b> F:
-            FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>,
-    {
-        self.interaction
-            .create_interaction_response(&self.bot, f)
-            .await
-    }
+            pub async fn create_interaction_response<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<()>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponse<'a>,
+                ) -> &'b mut CreateInteractionResponse<'a>;
 
-    pub async fn edit_original_response<F>(&self, f: F) -> serenity::Result<Message>
-    where
-        F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse,
-    {
-        self.interaction
-            .edit_original_interaction_response(&self.bot, f)
-            .await
-    }
+            pub async fn edit_original_interaction_response<F>(
+                &self,
+                [ &self.bot ],
+                f: F
+            ) -> serenity::Result<Message>
+            where
+                F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
 
-    pub async fn delete_original_response(&self) -> serenity::Result<()> {
-        self.interaction
-            .delete_original_interaction_response(&self.bot)
-            .await
-    }
+            pub async fn delete_original_interaction_response(
+                &self,
+                [ &self.bot ],
+            ) -> serenity::Result<()>;
 
-    pub async fn create_followup_message<'a, F>(&self, f: F) -> serenity::Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        self.interaction.create_followup_message(&self.bot, f).await
-    }
+            pub async fn create_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-    pub async fn edit_followup_message<'a, F, M: Into<MessageId>>(
-        &self,
-        message_id: M,
-        f: F,
-    ) -> serenity::Result<Message>
-    where
-        for<'b> F: FnOnce(
-            &'b mut CreateInteractionResponseFollowup<'a>,
-        ) -> &'b mut CreateInteractionResponseFollowup<'a>,
-    {
-        self.interaction
-            .edit_followup_message(&self.bot, message_id, f)
-            .await
-    }
+            pub async fn edit_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-    pub async fn delete_followup_message<M: Into<MessageId>>(
-        &self,
-        message_id: M,
-    ) -> serenity::Result<()> {
-        self.interaction
-            .delete_followup_message(&self.bot, message_id)
-            .await
-    }
+            pub async fn delete_followup_message(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+            ) -> serenity::Result<()>;
 
-    pub async fn get_followup_message<M: Into<MessageId>>(
-        &self,
-        message_id: M,
-    ) -> serenity::Result<Message> {
-        self.interaction
-            .get_followup_message(&self.bot, message_id)
-            .await
-    }
+            pub async fn get_followup_message(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+            ) -> serenity::Result<Message>;
 
-    pub async fn defer(&self) -> serenity::Result<()> {
-        self.interaction.defer(&self.bot).await
+            pub async fn defer(&self, [ &self.bot ]) -> serenity::Result<()>;
+        }
     }
 }
 

--- a/tranquil/src/lib.rs
+++ b/tranquil/src/lib.rs
@@ -2,6 +2,8 @@ pub mod autocomplete;
 pub mod bot;
 pub mod command;
 pub mod l10n;
+pub mod message_component;
+pub mod modal;
 pub mod module;
 pub mod resolve;
 pub mod utils;

--- a/tranquil/src/message_component.rs
+++ b/tranquil/src/message_component.rs
@@ -1,0 +1,85 @@
+use delegate::delegate;
+use serenity::{
+    builder::{
+        CreateInteractionResponse, CreateInteractionResponseFollowup, EditInteractionResponse,
+    },
+    client::Context,
+    model::{
+        application::interaction::message_component::MessageComponentInteraction, id::MessageId,
+        prelude::Message,
+    },
+};
+
+pub struct MessageComponentContext {
+    pub bot: Context,
+    pub interaction: MessageComponentInteraction,
+}
+
+impl MessageComponentContext {
+    delegate! {
+        to self.interaction {
+            pub async fn get_interaction_response(
+                &self,
+                [ &self.bot ],
+            ) -> serenity::Result<Message>;
+
+            pub async fn create_interaction_response<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<()>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponse<'a>,
+                ) -> &'b mut CreateInteractionResponse<'a>;
+
+            pub async fn edit_original_interaction_response<F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
+
+            pub async fn delete_original_interaction_response(
+                &self,
+                [ &self.bot ],
+            ) -> serenity::Result<()>;
+
+            pub async fn create_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
+
+            pub async fn edit_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
+
+            pub async fn delete_followup_message(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+            ) -> serenity::Result<()>;
+
+            pub async fn get_followup_message(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+            ) -> serenity::Result<Message>;
+
+            pub async fn defer(&self, [ &self.bot ]) -> serenity::Result<()>;
+        }
+    }
+}

--- a/tranquil/src/modal.rs
+++ b/tranquil/src/modal.rs
@@ -1,0 +1,75 @@
+use delegate::delegate;
+use serenity::{
+    builder::{
+        CreateInteractionResponse, CreateInteractionResponseFollowup, EditInteractionResponse,
+    },
+    client::Context,
+    model::{
+        application::interaction::modal::ModalSubmitInteraction, channel::Message, id::MessageId,
+    },
+};
+
+pub struct ModalContext {
+    pub bot: Context,
+    pub interaction: ModalSubmitInteraction,
+}
+
+impl ModalContext {
+    delegate! {
+        to self.interaction {
+            pub async fn get_interaction_response(&self, [ &self.bot ]) -> serenity::Result<Message>;
+
+            pub async fn create_interaction_response<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<()>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponse<'a>,
+                ) -> &'b mut CreateInteractionResponse<'a>;
+
+            pub async fn edit_original_interaction_response<F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
+
+            pub async fn delete_original_interaction_response(
+                &self,
+                [ &self.bot ],
+            ) -> serenity::Result<()>;
+
+            pub async fn create_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
+
+            pub async fn edit_followup_message<'a, F>(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+                f: F,
+            ) -> serenity::Result<Message>
+            where
+                for<'b> F: FnOnce(
+                    &'b mut CreateInteractionResponseFollowup<'a>,
+                ) -> &'b mut CreateInteractionResponseFollowup<'a>;
+
+            pub async fn delete_followup_message(
+                &self,
+                [ &self.bot ],
+                message_id: impl Into<MessageId>,
+            ) -> serenity::Result<()>;
+
+            pub async fn defer(&self, [ &self.bot ]) -> serenity::Result<()>;
+        }
+    }
+}


### PR DESCRIPTION
- Keep the original function names instead of simplifying some.
- Also add `Context` types for message components and modals.
- Split `Bot::interaction_create` logic into different functions.