### PR TITLE
Rename delegates to match serenity 0.12

### DIFF
--- a/tranquil/examples/autocomplete/autocomplete_module.rs
+++ b/tranquil/examples/autocomplete/autocomplete_module.rs
@@ -18,7 +18,7 @@ impl AutocompleteModule {
     ) -> anyhow::Result<()> {
         let you_typed = format!("You typed: {value}");
 
-        ctx.create_autocomplete_response(|response| response.add_string_choice(you_typed, value))
+        ctx.create_response(|response| response.add_string_choice(you_typed, value))
             .await?;
 
         Ok(())
@@ -39,7 +39,7 @@ impl AutocompleteModule {
         let optional_autocompleted_completion =
             format!("optional_autocompleted: {optional_autocompleted:?}");
 
-        ctx.create_autocomplete_response(|response| {
+        ctx.create_response(|response| {
             response
                 .add_string_choice(
                     not_autocompleted_completion,
@@ -71,7 +71,7 @@ impl AutocompleteModule {
         ctx: CommandCtx,
         value: Autocomplete<String>,
     ) -> anyhow::Result<()> {
-        ctx.create_interaction_response(|response| {
+        ctx.create_response(|response| {
             response
                 .interaction_response_data(|data| data.content(format!("```rust\n{value:?}\n```")))
         })
@@ -88,7 +88,7 @@ impl AutocompleteModule {
         optional: Option<String>,
         optional_autocompleted: Autocomplete<Option<String>>,
     ) -> anyhow::Result<()> {
-        ctx.create_interaction_response(|response| {
+        ctx.create_response(|response| {
             response.interaction_response_data(|data| {
                 data.content(format!(
                     indoc! {r#"

--- a/tranquil/examples/l10n/example_module.rs
+++ b/tranquil/examples/l10n/example_module.rs
@@ -17,7 +17,7 @@ impl Module for ExampleModule {
 }
 
 async fn pong(ctx: CommandCtx) -> anyhow::Result<()> {
-    ctx.create_interaction_response(|response| {
+    ctx.create_response(|response| {
         response.interaction_response_data(|data| data.content("Pong!"))
     })
     .await?;

--- a/tranquil/examples/options/echo_module.rs
+++ b/tranquil/examples/options/echo_module.rs
@@ -492,7 +492,7 @@ impl EchoModule {
 }
 
 async fn echo(ctx: CommandCtx, value: impl std::fmt::Debug) -> anyhow::Result<()> {
-    ctx.create_interaction_response(|response| {
+    ctx.create_response(|response| {
         response.interaction_response_data(|data| data.content(format!("```rust\n{value:#?}\n```")))
     })
     .await?;

--- a/tranquil/examples/ping_module/ping_module.rs
+++ b/tranquil/examples/ping_module/ping_module.rs
@@ -11,7 +11,7 @@ pub(crate) struct PingModule;
 impl PingModule {
     #[slash]
     async fn ping(&self, ctx: CommandCtx) -> anyhow::Result<()> {
-        ctx.create_interaction_response(|response| {
+        ctx.create_response(|response| {
             response.interaction_response_data(|data| data.content("Pong!"))
         })
         .await?;

--- a/tranquil/examples/subcommands/subcommand_module.rs
+++ b/tranquil/examples/subcommands/subcommand_module.rs
@@ -8,7 +8,7 @@ use tranquil::{
 pub(crate) struct SubcommandModule;
 
 async fn pong(ctx: CommandCtx) -> anyhow::Result<()> {
-    ctx.create_interaction_response(|response| {
+    ctx.create_response(|response| {
         response.interaction_response_data(|data| data.content("Pong!"))
     })
     .await?;

--- a/tranquil/src/bot.rs
+++ b/tranquil/src/bot.rs
@@ -34,7 +34,7 @@ use uuid::Uuid;
 
 use crate::{
     command::{CommandMap, CommandMapEntry, CommandPath, SubcommandMapEntry},
-    context::{AutocompleteCtx, CommandCtx, Ctx, MessageComponentCtx, ModalCtx},
+    context::{AutocompleteCtx, CommandCtx, ComponentCtx, Ctx, ModalCtx},
     l10n::{CommandPathRef, L10n},
     module::Module,
 };
@@ -247,7 +247,7 @@ impl Bot {
         match self.command_map.find_command(&command_path) {
             Some(command) => command.run(ctx).await?,
             None => {
-                ctx.create_interaction_response(|response| {
+                ctx.create_response(|response| {
                     response.interaction_response_data(|data| {
                         data.embed(|embed| {
                             embed.color(colors::css::DANGER).field(
@@ -282,7 +282,7 @@ impl Bot {
             })
     }
 
-    async fn handle_message_component(&self, mut ctx: MessageComponentCtx) -> anyhow::Result<()> {
+    async fn handle_message_component(&self, mut ctx: ComponentCtx) -> anyhow::Result<()> {
         match ctx.interaction.data.component_type {
             ComponentType::Button | ComponentType::SelectMenu => {
                 let custom_id = take(&mut ctx.interaction.data.custom_id);
@@ -304,8 +304,7 @@ impl Bot {
             Some(command) => command.autocomplete(ctx).await?,
             None => {
                 // Commands are probably outdated... Send an empty autocomplete response.
-                ctx.create_autocomplete_response(|response| response)
-                    .await?
+                ctx.create_response(|response| response).await?
             }
         }
 

--- a/tranquil/src/context.rs
+++ b/tranquil/src/context.rs
@@ -36,18 +36,20 @@ impl<T: Send + Sync> CacheHttp for Ctx<T> {
 
 pub type CommandCtx = Ctx<ApplicationCommandInteraction>;
 pub type AutocompleteCtx = Ctx<AutocompleteInteraction>;
-pub type MessageComponentCtx = Ctx<MessageComponentInteraction>;
+pub type ComponentCtx = Ctx<MessageComponentInteraction>;
 pub type ModalCtx = Ctx<ModalSubmitInteraction>;
 
 impl CommandCtx {
     delegate! {
         to self.interaction {
-            pub async fn get_interaction_response(
+            #[call(get_interaction_response)]
+            pub async fn get_response(
                 &self,
                 [ &self.bot ],
             ) -> serenity::Result<Message>;
 
-            pub async fn create_interaction_response<'a, F>(
+            #[call(create_interaction_response)]
+            pub async fn create_response<'a, F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -57,7 +59,8 @@ impl CommandCtx {
                     &'b mut CreateInteractionResponse<'a>,
                 ) -> &'b mut CreateInteractionResponse<'a>;
 
-            pub async fn edit_original_interaction_response<F>(
+            #[call(edit_original_interaction_response)]
+            pub async fn edit_response<F>(
                 &self,
                 [ &self.bot ],
                 f: F
@@ -65,12 +68,14 @@ impl CommandCtx {
             where
                 F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
 
-            pub async fn delete_original_interaction_response(
+            #[call(delete_original_interaction_response)]
+            pub async fn delete_response(
                 &self,
                 [ &self.bot ],
             ) -> serenity::Result<()>;
 
-            pub async fn create_followup_message<'a, F>(
+            #[call(create_followup_message)]
+            pub async fn create_followup<'a, F>(
                 &self,
                 [ &self.bot ],
                 f: F
@@ -80,7 +85,8 @@ impl CommandCtx {
                     &'b mut CreateInteractionResponseFollowup<'a>,
                 ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-            pub async fn edit_followup_message<'a, F>(
+            #[call(edit_followup_message)]
+            pub async fn edit_followup<'a, F>(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
@@ -97,7 +103,8 @@ impl CommandCtx {
                 message_id: impl Into<MessageId>,
             ) -> serenity::Result<()>;
 
-            pub async fn get_followup_message(
+            #[call(get_followup_message)]
+            pub async fn get_followup(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
@@ -111,7 +118,8 @@ impl CommandCtx {
 impl AutocompleteCtx {
     delegate! {
         to self.interaction {
-            pub async fn create_autocomplete_response<F>(
+            #[call(create_autocomplete_response)]
+            pub async fn create_response<F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -122,15 +130,17 @@ impl AutocompleteCtx {
     }
 }
 
-impl MessageComponentCtx {
+impl ComponentCtx {
     delegate! {
         to self.interaction {
-            pub async fn get_interaction_response(
+            #[call(get_interaction_response)]
+            pub async fn get_response(
                 &self,
                 [ &self.bot ],
             ) -> serenity::Result<Message>;
 
-            pub async fn create_interaction_response<'a, F>(
+            #[call(create_interaction_response)]
+            pub async fn create_response<'a, F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -140,7 +150,8 @@ impl MessageComponentCtx {
                     &'b mut CreateInteractionResponse<'a>,
                 ) -> &'b mut CreateInteractionResponse<'a>;
 
-            pub async fn edit_original_interaction_response<F>(
+            #[call(edit_original_interaction_response)]
+            pub async fn edit_response<F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -148,12 +159,14 @@ impl MessageComponentCtx {
             where
                 F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
 
-            pub async fn delete_original_interaction_response(
+            #[call(delete_original_interaction_response)]
+            pub async fn delete_response(
                 &self,
                 [ &self.bot ],
             ) -> serenity::Result<()>;
 
-            pub async fn create_followup_message<'a, F>(
+            #[call(create_followup_message)]
+            pub async fn create_followup<'a, F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -163,7 +176,8 @@ impl MessageComponentCtx {
                     &'b mut CreateInteractionResponseFollowup<'a>,
                 ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-            pub async fn edit_followup_message<'a, F>(
+            #[call(edit_followup_message)]
+            pub async fn edit_followup<'a, F>(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
@@ -174,13 +188,15 @@ impl MessageComponentCtx {
                     &'b mut CreateInteractionResponseFollowup<'a>,
                 ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-            pub async fn get_followup_message(
+            #[call(get_followup_message)]
+            pub async fn get_followup(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
             ) -> serenity::Result<Message>;
 
-            pub async fn delete_followup_message(
+            #[call(delete_followup_message)]
+            pub async fn delete_followup(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
@@ -194,9 +210,11 @@ impl MessageComponentCtx {
 impl ModalCtx {
     delegate! {
         to self.interaction {
-            pub async fn get_interaction_response(&self, [ &self.bot ]) -> serenity::Result<Message>;
+            #[call(get_interaction_response)]
+            pub async fn get_response(&self, [ &self.bot ]) -> serenity::Result<Message>;
 
-            pub async fn create_interaction_response<'a, F>(
+            #[call(create_interaction_response)]
+            pub async fn create_response<'a, F>(
                 &self,
                 [ &self.bot ],
                 f: F,
@@ -206,22 +224,26 @@ impl ModalCtx {
                     &'b mut CreateInteractionResponse<'a>,
                 ) -> &'b mut CreateInteractionResponse<'a>;
 
-            pub async fn edit_original_interaction_response<F>(&self, [ &self.bot ], f: F) -> serenity::Result<Message>
+            #[call(edit_original_interaction_response)]
+            pub async fn edit_response<F>(&self, [ &self.bot ], f: F) -> serenity::Result<Message>
             where
                 F: FnOnce(&mut EditInteractionResponse) -> &mut EditInteractionResponse;
 
-            pub async fn delete_original_interaction_response(
+            #[call(delete_original_interaction_response)]
+            pub async fn delete_response(
                 &self,
                 [ &self.bot ],
             ) -> serenity::Result<()>;
 
-            pub async fn create_followup_message<'a, F>(&self, [ &self.bot ], f: F) -> serenity::Result<Message>
+            #[call(create_followup_message)]
+            pub async fn create_followup<'a, F>(&self, [ &self.bot ], f: F) -> serenity::Result<Message>
             where
                 for<'b> F: FnOnce(
                     &'b mut CreateInteractionResponseFollowup<'a>,
                 ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-            pub async fn edit_followup_message<'a, F>(
+            #[call(edit_followup_message)]
+            pub async fn edit_followup<'a, F>(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,
@@ -232,7 +254,8 @@ impl ModalCtx {
                     &'b mut CreateInteractionResponseFollowup<'a>,
                 ) -> &'b mut CreateInteractionResponseFollowup<'a>;
 
-            pub async fn delete_followup_message(
+            #[call(delete_followup_message)]
+            pub async fn delete_followup(
                 &self,
                 [ &self.bot ],
                 message_id: impl Into<MessageId>,

--- a/tranquil/src/interaction.rs
+++ b/tranquil/src/interaction.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{de::DeserializeOwned, Serialize};
 use uuid::Uuid;
 
-use crate::{context::MessageComponentCtx, module::Module};
+use crate::{context::ComponentCtx, module::Module};
 
 #[async_trait]
 pub trait Interact: Serialize + DeserializeOwned {
@@ -10,7 +10,7 @@ pub trait Interact: Serialize + DeserializeOwned {
 
     type Module: Module;
 
-    async fn interact(self, module: &Self::Module, ctx: MessageComponentCtx) -> anyhow::Result<()>;
+    async fn interact(self, module: &Self::Module, ctx: ComponentCtx) -> anyhow::Result<()>;
 }
 
 #[macro_export]
@@ -25,7 +25,7 @@ macro_rules! handle_interactions {
             &'life0 self,
             uuid: $crate::uuid::Uuid,
             state: &'life1 str,
-            ctx: $crate::context::MessageComponentCtx,
+            ctx: $crate::context::ComponentCtx,
         ) -> ::std::pin::Pin<
             ::std::boxed::Box<
                 dyn ::std::future::Future<Output = $crate::anyhow::Result<()>>

--- a/tranquil/src/modal.rs
+++ b/tranquil/src/modal.rs
@@ -7,7 +7,7 @@ use serenity::{
 use uuid::Uuid;
 
 use crate::{
-    context::{CommandCtx, MessageComponentCtx},
+    context::{CommandCtx, ComponentCtx},
     custom_id::custom_id_encode,
 };
 
@@ -86,7 +86,7 @@ impl Modal {
                 .collect(),
         );
 
-        ctx.create_interaction_response(move |response| {
+        ctx.create_response(move |response| {
             response
                 .kind(InteractionResponseType::Modal)
                 .interaction_response_data(move |data| {
@@ -162,7 +162,7 @@ impl TextInput {
 
 #[async_trait]
 pub trait RespondCtx {
-    async fn create_interaction_response<'a, F>(&self, f: F) -> serenity::Result<()>
+    async fn create_response<'a, F>(&self, f: F) -> serenity::Result<()>
     where
         for<'b> F: FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>
             + Send;
@@ -170,22 +170,22 @@ pub trait RespondCtx {
 
 #[async_trait]
 impl RespondCtx for CommandCtx {
-    async fn create_interaction_response<'a, F>(&self, f: F) -> serenity::Result<()>
+    async fn create_response<'a, F>(&self, f: F) -> serenity::Result<()>
     where
         for<'b> F: FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>
             + Send,
     {
-        self.create_interaction_response(f).await
+        self.create_response(f).await
     }
 }
 
 #[async_trait]
-impl RespondCtx for MessageComponentCtx {
-    async fn create_interaction_response<'a, F>(&self, f: F) -> serenity::Result<()>
+impl RespondCtx for ComponentCtx {
+    async fn create_response<'a, F>(&self, f: F) -> serenity::Result<()>
     where
         for<'b> F: FnOnce(&'b mut CreateInteractionResponse<'a>) -> &'b mut CreateInteractionResponse<'a>
             + Send,
     {
-        self.create_interaction_response(f).await
+        self.create_response(f).await
     }
 }

--- a/tranquil/src/module.rs
+++ b/tranquil/src/module.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 
 use crate::{
     command::CommandProvider,
-    context::{MessageComponentCtx, ModalCtx},
+    context::{ComponentCtx, ModalCtx},
     l10n::{L10n, L10nLoadError},
 };
 
@@ -24,12 +24,7 @@ pub trait Module: CommandProvider + Send + Sync {
         &[]
     }
 
-    async fn interact(
-        &self,
-        _uuid: Uuid,
-        _state: &str,
-        _ctx: MessageComponentCtx,
-    ) -> anyhow::Result<()> {
+    async fn interact(&self, _uuid: Uuid, _state: &str, _ctx: ComponentCtx) -> anyhow::Result<()> {
         panic!("module does not handle any interactions")
     }
 

--- a/tranquil/src/select_menu.rs
+++ b/tranquil/src/select_menu.rs
@@ -8,8 +8,7 @@ use serenity::{builder::CreateSelectMenu, model::channel::ReactionType};
 use uuid::Uuid;
 
 use crate::{
-    context::MessageComponentCtx, custom_id::custom_id_encode, interaction::Interact,
-    module::Module,
+    context::ComponentCtx, custom_id::custom_id_encode, interaction::Interact, module::Module,
 };
 
 pub struct SelectMenu {
@@ -173,7 +172,7 @@ impl<T: Select + Sync> Interact for SelectHandler<T> {
 
     type Module = T::Module;
 
-    async fn interact(self, module: &Self::Module, ctx: MessageComponentCtx) -> anyhow::Result<()> {
+    async fn interact(self, module: &Self::Module, ctx: ComponentCtx) -> anyhow::Result<()> {
         let values = &ctx.interaction.data.values;
 
         if values.len() != 1 {
@@ -186,7 +185,7 @@ impl<T: Select + Sync> Interact for SelectHandler<T> {
 
 #[async_trait]
 pub trait Select: SelectMenuChoice {
-    async fn select(self, module: &Self::Module, ctx: MessageComponentCtx) -> anyhow::Result<()>;
+    async fn select(self, module: &Self::Module, ctx: ComponentCtx) -> anyhow::Result<()>;
 }
 
 pub use tranquil_macros::SelectMenuOptions;
@@ -220,7 +219,7 @@ where
 
     type Module = T::Module;
 
-    async fn interact(self, module: &Self::Module, ctx: MessageComponentCtx) -> anyhow::Result<()> {
+    async fn interact(self, module: &Self::Module, ctx: ComponentCtx) -> anyhow::Result<()> {
         T::multi_select(T::from_values(&ctx.interaction.data.values)?, module, ctx).await
     }
 }
@@ -230,6 +229,6 @@ pub trait MultiSelect: SelectMenuOptions {
     async fn multi_select(
         values: EnumSet<Self>,
         module: &Self::Module,
-        ctx: MessageComponentCtx,
+        ctx: ComponentCtx,
     ) -> anyhow::Result<()>;
 }


### PR DESCRIPTION
- `MessageComponentCtx` -> `ComponentCtx`
- `create_interaction_response` -> `create_response`
- ... and similar