### PR TITLE
`Bot::register` now also supports passing an `Arc` directly

### DIFF
--- a/tranquil/src/bot.rs
+++ b/tranquil/src/bot.rs
@@ -74,6 +74,22 @@ impl Default for Bot {
     }
 }
 
+pub trait IntoArcModule {
+    fn into_arc_module(self) -> Arc<dyn Module>;
+}
+
+impl<T: Module + 'static> IntoArcModule for T {
+    fn into_arc_module(self) -> Arc<dyn Module> {
+        Arc::new(self)
+    }
+}
+
+impl<T: Module + 'static> IntoArcModule for Arc<T> {
+    fn into_arc_module(self) -> Arc<dyn Module> {
+        self
+    }
+}
+
 impl Bot {
     pub fn new() -> Self {
         Default::default()
@@ -87,8 +103,8 @@ impl Bot {
         self
     }
 
-    pub fn register(mut self, module: impl Module + 'static) -> Self {
-        self.modules.push(Arc::new(module));
+    pub fn register(mut self, module: impl IntoArcModule) -> Self {
+        self.modules.push(module.into_arc_module());
         self
     }
 


### PR DESCRIPTION
This is necessary if you want to have a `Weak` reference inside the module itself.

This allows e.g. the creation of an immediately running background task that stores a `Weak` to itself.